### PR TITLE
update default trait properies, add doc ref o default properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ ReplayApi.configure do |config|
 end
 ```
 
+For predefined list refer to [event properties][2] and [trait properties][3].
 
 ## Contributing
 
@@ -110,3 +111,5 @@ end
 
 
   [1]: https://github.com/solnic/virtus
+  [2]: lib/replay_api/event_properties.rb
+  [3]: lib/replay_api/trait_properties.rb

--- a/lib/replay_api/event_properties.rb
+++ b/lib/replay_api/event_properties.rb
@@ -5,13 +5,13 @@ module ReplayApi
     attribute :app_version, String
     attribute :client_os, String
     attribute :client_sdk, String
+    attribute :country, String
     attribute :device_brand, String
     attribute :device_carrier, String
     attribute :device_id, String
     attribute :device_manufacturer, String
     attribute :device_model, String
     attribute :device_type, String
-    attribute :country, String
     attribute :event_category, String, default: 'general'
     attribute :ip, String
     attribute :language, String
@@ -20,6 +20,6 @@ module ReplayApi
     attribute :page_name, String
     attribute :page_url, String
     attribute :past_event, Integer, default: 0
-    
+
   end
 end

--- a/lib/replay_api/trait_properties.rb
+++ b/lib/replay_api/trait_properties.rb
@@ -7,6 +7,7 @@ module ReplayApi
     attribute :age, Integer
     attribute :birthday, String
     attribute :avatar, String
+    attribute :company, String
     attribute :created_at, Integer
     attribute :description, String
     attribute :email, String
@@ -21,8 +22,6 @@ module ReplayApi
     attribute :page_url, String
     attribute :past_event, Integer, default: 0
     attribute :phone, String
-    attribute :title, String
-    attribute :username, String
 
   end
 end

--- a/lib/replay_api/trait_properties.rb
+++ b/lib/replay_api/trait_properties.rb
@@ -5,8 +5,8 @@ module ReplayApi
 
     attribute :address, Address, default: -> (_, _) { Address.new }
     attribute :age, Integer
-    attribute :birthday, String
     attribute :avatar, String
+    attribute :birthday, String
     attribute :company, String
     attribute :created_at, Integer
     attribute :description, String


### PR DESCRIPTION
@bentona @jimmzhu I've checked on the list of properies used in mappers `username` and `title` is not used anywhere, while `company` is more common, also added link to list of default properties
